### PR TITLE
Renamed and reorganized API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v.1.7.0 (25/09/2023)
+Renamed API endpoints and organized them by resource.
+- Renamed ` POST /new_alert` to `POST /alerts/`.
+- Renamed `GET /last_alert/` to  `GET /alerts/latest/`.
+- Renamed `GET /cap/{identidier}` to `GET /alerts/{identifier}/cap/`. This endpoint takes
+the optional argument 'save' that takes on the values 'true' or 'false'. If set to 'true' indicates
+to download the cap file. Else, the cap files contents are returned as part of the JSON response.
+- Removed `GET /cap_contents/{identifier}` as its now part of the `/alertst/{identifier}/cap/` endpoint.
+
 ## v1.6.0 (19/09/2023)
 
 ### API

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Authentication is required to post alerts. Include the Authorization header with
 
 #### Add new alert
 
-- **Endpoint**: POST /new_alert
+- **Endpoint**: POST /alerts/
 - **Description**: Add a new alert
 - **Request Format**: JSON
 - **Request Example**:
@@ -165,40 +165,6 @@ only used when the alert is an update of a previous one.
   "is_event": false,
   "id": "AlertID3",
   "references": ["ALERTID1", "ALERTID2"]
-}
-```
-
-#### Get alerts by date
-
-- **Endpoint**: GET /alerts/dates/{date}
-- **Description**: Get all the alerts that were emitted in the given date.
-- **Parameters**:
-  - `end`: (optional): If end is used it will get alerts in the range from `date` to 
-    `end`(inclusive).
-- **Response Format**: JSON
-- **Response Example**:
-
-
-```json
-{
-      "alerts": [
-          {
-              "time": "2023-09-13T15:00:00",
-              "states": [40],
-              "region": 41201,
-              "is_event": false,
-              "id": "ALERT1",
-              "references": []
-          },
-          {
-              "time": "2023-09-13T18:00:00",
-              "states": [41],
-              "region": 41204,
-              "is_event": false,
-              "id": "ALERT2",
-              "references": []
-          }
-      ]
 }
 ```
 
@@ -254,7 +220,7 @@ only used when the alert is an update of a previous one.
 
 #### Get last alert
 
-- **Endpoint**: GET /last_alert/
+- **Endpoint**: GET /alerts/latest/
 - **Description**: Get the latest alert.
 - **Response Format**: JSON
 - **Response Example**:
@@ -273,9 +239,12 @@ only used when the alert is an update of a previous one.
 
 #### Get cap file by identifier
 
-- **Endpoint**: GET /cap/{identifier}
+- **Endpoint**: GET /alerts/{identifier}/cap/
 - **Description**: Get the alert with the given identifier in CAP file format.
-- **Response Format**: CAP file
+- **Parameters**:
+  - `{save}`: Whether to download a cap file or return the contents of the cap file on the json response.
+Can only take the values true or false. 
+- **Response Format**: CAP file or JSON
 
 
 ## Region codes

--- a/src/rss/__main__.py
+++ b/src/rss/__main__.py
@@ -135,6 +135,8 @@ def main():
         )
     elif args.entry == "server":
         start_server()
+    elif args.entry is None:
+        return
     else:
         raise ValueError(f"Invalid mode {args.entry}")
 

--- a/src/rss/services/api_client.py
+++ b/src/rss/services/api_client.py
@@ -14,13 +14,12 @@ class APIClient:
         self.credentials = (CONFIG.API_USER, CONFIG.API_PASSWORD)
 
     def post_alert(self, alert: Alert, save_path: str = "") -> requests.Response:
-        """ Post a new alert.
-        """
+        """ Post a new alert. """
         references = []
         if alert.refs is not None:
             references = [ref.id for ref in alert.refs]
 
-        url = f"{self.base_url}/new_alert"
+        url = f"{self.base_url}/alerts/"
         if save_path:
             url += f"?save_path={save_path}"
 
@@ -75,8 +74,8 @@ class APIClient:
 
     def get_cap_file(self, identifier: str) -> requests.Response:
         """ Returns a response with the contents of the solicited cap file as string"""
-        return requests.get(f"{self.base_url}/cap_contents/{identifier}")
+        return requests.get(f"{self.base_url}/alerts/{identifier}/cap?save=false")
 
     def get_last_alert(self) -> requests.Response:
         """ Fetch the last published alert. """
-        return requests.get(f"{self.base_url}/last_alert/")
+        return requests.get(f"{self.base_url}/alerts/latest/")

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -256,7 +256,7 @@ class TestFeedPoster:
         assert alerts.empty()
 
         url = poster.client.base_url
-        url += "/new_alert"
+        url += "/alerts/"
 
         mock_post.assert_called_once_with(
             url,


### PR DESCRIPTION
Renamed API endpoints and organized them by resource.
- Renamed ` POST /new_alert` to `POST /alerts/`.
- Renamed `GET /last_alert/` to  `GET /alerts/latest/`.
- Renamed `GET /cap/{identifier}` to `GET /alerts/{identifier}/cap/`. This endpoint takes
the optional argument 'save' that takes on the values 'true' or 'false'. If set to 'true' indicates
to download the cap file. Else, the cap files contents are returned as part of the JSON response.
- Removed `GET /cap_contents/{identifier}` as its now part of the `/alertst/{identifier}/cap/` endpoint.